### PR TITLE
Maint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ test = [
     "numpy",
     "pytest",
     "pytest-cov",
-    "ruff==0.6.9",
+    "ruff==0.12.9",
     "nox"]
 
 [tool.ruff]

--- a/src/scitrack/__init__.py
+++ b/src/scitrack/__init__.py
@@ -243,7 +243,7 @@ def set_logger(log_file_path, level=logging.DEBUG, mode="w"):
     logging.info(f"system_details : system={platform.version()}")
     logging.info(f"python : {platform.python_version()}")
     logging.info(f"user : {getuser()}")
-    logging.info(f'command_string : {" ".join(sys.argv)}')
+    logging.info(f"command_string : {' '.join(sys.argv)}")
     return handler
 
 


### PR DESCRIPTION
## Summary by Sourcery

Update linting dependency and fix logging f-string syntax

Enhancements:
- Standardize f-string quoting in logging.info for command_string

Build:
- Bump ruff version from 0.6.9 to 0.12.9 in development dependencies