### PR TITLE
DEV: bump version to 2026.6.8

### DIFF
--- a/src/scitrack/__init__.py
+++ b/src/scitrack/__init__.py
@@ -15,7 +15,7 @@ import types
 from getpass import getuser
 from pathlib import Path
 
-__version__ = "2024.10.8"
+__version__ = "2026.6.8"
 
 
 VERSION_ATTRS = ["__version__", "version", "VERSION"]


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Update the library __version__ constant to the new 2026.6.8 release number.