### PR TITLE
DEV: fix GH action release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on: [workflow_dispatch]
 jobs:
   test:
     name: "Test on Python ${{ matrix.python-version }} (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Configure the release workflow test job to use the matrix-defined runner via runs-on: ${{ matrix.os }}.