### PR TITLE
DEV: fixed coverage capture and update reporting link

### DIFF
--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -35,7 +35,7 @@ jobs:
         run: uv tool install nox
 
       - name: "Run nox for ${{ matrix.python-version }}"
-        run: "nox -db uv -s test-${{ matrix.python-version }} -- --cov-report lcov:lcov-${{matrix.os}}-${{matrix.python-version}}.lcov --cov-report term --cov-append --cov scitrack"
+        run: "nox -db uv -s test-${{ matrix.python-version }} -- --cov-config=${{ github.workspace }}/pyproject.toml --cov-report lcov:lcov-${{matrix.os}}-${{matrix.python-version}}.lcov --cov-report term --cov-append --cov scitrack"
 
 
       - name: trust coveralls (macOS)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CI](https://github.com/HuttleyLab/scitrack/actions/workflows/testing_develop.yml/badge.svg)](https://github.com/HuttleyLab/scitrack/actions/workflows/testing_develop.yml)
-[![coverall](https://coveralls.io/repos/github/GavinHuttley/scitrack/badge.svg?branch=develop)](https://coveralls.io/github/GavinHuttley/scitrack?branch=develop)
+[![Coverage Status](https://coveralls.io/repos/github/HuttleyLab/scitrack/badge.svg?branch=develop)](https://coveralls.io/github/HuttleyLab/scitrack?branch=develop)
 [![Using Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/release/python-310/)
 


### PR DESCRIPTION
## Summary by Sourcery

Update coverage configuration usage in CI and fix coverage badge link.

CI:
- Configure nox test runs in the develop testing workflow to use the coverage settings from pyproject.toml.

Documentation:
- Update the README coverage badge to reference the HuttleyLab/scitrack repository on Coveralls.